### PR TITLE
マイページ(userとfavorite)の実装、編集機能追加

### DIFF
--- a/app/assets/javascripts/favorites.coffee
+++ b/app/assets/javascripts/favorites.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,5 @@
 @import "layouts/navbar";
 @import "common";
 @import "users/devise";
+@import "users/show";
+@import "users/edit";

--- a/app/assets/stylesheets/favorites.scss
+++ b/app/assets/stylesheets/favorites.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the favorites controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,0 +1,13 @@
+.profile-form-wrap {
+  background: #fff;
+  padding: 20px;
+  border: 1px solid #e6e6e6;
+}
+
+.profile-form-wrap label {
+  font-weight: bold;
+}
+
+.edit-profile-wrapper {
+  margin-top: 60px;
+}

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -1,0 +1,42 @@
+.profile-wrap{
+  margin:40px 0px;
+}
+
+.round-img{
+  border-radius:50%;
+  width: 120px;
+  height: 120px;
+}
+
+.edit-profile-btn {
+  margin: 15px 0 0 15px;
+  font-weight: bold;
+  height: 26px;
+  line-height: 26px;
+  padding: 0 26px;
+  border-color: #dbdbdb;
+  font-size: 14px;
+}
+
+.setting {
+  background-image: image-url("parts4.png");
+  background-repeat: no-repeat;
+  height: 24px;
+  width: 24px;
+  background-color: transparent;
+  margin: 18px 0 0 10px;
+  background-size: 22px!important;
+  border: none;
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.row0 {
+  padding: 10px;
+}
+
+.row4 {
+  margin-top: 30px;
+  display: flex;
+}

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,26 @@
+class FavoritesController < ApplicationController
+
+  before_action :set_favorite, only: [:edit, :update]
+
+  def edit
+    @user = User.find_by(id: params[:user_id])
+  end
+
+  def update
+    if @favorite.update_attributes(favorite_params)
+      redirect_to user_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def favorite_params
+    params.require(:favorite).permit(:team, :player, :headcoach).merge(user_id: current_user.id)
+  end
+
+  def set_favorite
+    @favorite = Favorite.find_by(id: params[:id])
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,4 +39,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
     params.require(:favorite).permit(:team, :player, :headcoach)
   end
 
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
+  end
+
+  def after_update_path_for(resource)
+    user_path(resource)
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+
+  def show
+    @user = User.find_by(id: params[:id])
+    @favorite = Favorite.find_by(id: params[:id])
+  end
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,7 @@
+module UsersHelper
+  def avatar_url(user)
+    return user.profile_photo unless user.profile_photo.nil?
+    gravatar_id = Digest::MD5::hexdigest(user.email).downcase
+    "https://www.gravatar.com/avatar/#{gravatar_id}.jpg"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,17 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 50 }
   has_one :favorite
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,18 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+.col-md-offset-2.mb-4.edit-profile-wrapper
+  .row
+    .col-md-8.mx-auto
+      .profile-form-wrap
+        = form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true, method: :patch do |f|
+          .form-group
+            = f.label :name, "名前"
+            = f.text_field :name, autofocus: true, class: "form-control"
+          .form-group
+            = f.label :email, "メールアドレス"
+            = f.email_field :email, autofocus: true, class: "form-control"
+          .form-group
+            = f.label :password, "パスワード"
+            = f.password_field :password, autofocus: "off", class: "form-control"
+          .form-group
+            = f.label :password_confirmation, "パスワードの確認"
+            = f.password_field :password_confirmation, autofocus: "off", class: "form-control"
+          = f.submit "変更する", class: "btn btn-primary"

--- a/app/views/favorites/edit.html.haml
+++ b/app/views/favorites/edit.html.haml
@@ -1,0 +1,22 @@
+.main
+  .card.devise-card
+    .form-wrap
+      .form-group.text-center
+        %h2.logo-img.mx-auto
+        %p.text-secondary 応援しているチームや選手・HCが編集できるよ！
+      -# = form_with scope: @favorite, as: @favorite, local:true do |f|
+      -# = form_for @favorite do |f|
+      = form_with model: @favorite, url: { action: :update }, local: true do |f|
+        .form-group
+          = f.label :team
+          = f.text_field :team, autofocus: true, placeholder: "好きなチームは？", class: "form-control"
+        .form-group
+          = f.label :player
+          = f.text_field :player, autofocus: true, placeholder: "好きな選手は？", class: "form-control"
+        .form-group
+          = f.label :headcoach
+          = f.text_field :headcoach, autofocus: true, placeholder: "好きなHCやコーチは？", class: "form-control"
+        .actions
+          = f.submit "編集する", class: "btn btn-primary w-100"
+
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,6 +5,7 @@
     %title Oneteam
     = csrf_meta_tags
     = csp_meta_tag
+    %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
@@ -16,5 +17,6 @@
       - if flash[:alert]
         .alert.alert-danger
           = flash[:alert]
-      = yield
+      .container
+        = yield
       = render 'partial/footer'

--- a/app/views/partial/_navbar.html.haml
+++ b/app/views/partial/_navbar.html.haml
@@ -8,4 +8,4 @@
         %li
           = link_to "投稿","#",class:"btn btn-primary"
         %li
-          = link_to "", "#",class:"nav-link commonNavIcon profile-icon"
+          = link_to "", user_path(current_user),class:"nav-link commonNavIcon profile-icon"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,52 @@
+.profile-wrap
+  .row
+    .col-md-4.text-center
+      = image_tag avatar_url(@user), class: "round-img"
+    .col-md-8
+      .row
+        %h1= @user.name
+        - if @user == current_user
+          = link_to "プロフィールを編集", edit_user_registration_path, class: "btn btn-outline-dark edit-profile-btn"
+          %button.setting{"data-target" => "#exampleModal", "data-toggle" => "modal", :type => "button"}
+
+        #exampleModal.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "exampleModalLabel", :role => "dialog", :tabindex => "-1"}
+          .modal-dialog{:role => "document"}
+            .modal-content
+              .modal-header
+                %h5#exampleModalLabel.modal-title 設定
+                %button.close{"aria-label" => "Close", "data-dismiss" => "modal", :type => "button"}
+                  %span{"aria-hidden" => "true"} ×
+              .list-group.text-center
+                = link_to "サインアウト", destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action"
+                = link_to "キャンセル", "#", class: "list-group-item list-group-item-action", "data-dismiss": "modal"
+      - if @user == current_user
+        .row
+          %p
+            = @user.email
+      - if @favorite.present?
+        .row4
+          %h2.row4__1 Support Info
+          = link_to "Support Infoを編集", edit_favorite_path, class: "btn btn-outline-dark common-btn edit-profile-btn"
+        .row0
+          .row0__1
+          応援しているチーム
+          .row0__2
+            %h5
+              = @favorite.team
+        %br/
+        .row0
+          .row0__1
+          応援している選手
+          .row0__2
+            %h5
+              = @favorite.player
+        %br/
+        .row0
+          .row0__1
+          応援している監督
+          .row0__2
+            %h5
+              = @favorite.headcoach
+
+          
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,14 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: {
-    registrations: 'users/registrations',
-  }
+  devise_for :users, 
+  controllers: {registrations: 'users/registrations'}
   devise_scope :user do
     get 'favorites', to: 'users/registrations#new_favorite'
     post 'favorites', to: 'users/registrations#create_favorite'
   end
   root to: "pages#home"
+
+  resources :favorites, only: [:edit, :update]
+
+  resources :users, only: [:show]
 
 end

--- a/db/migrate/20200401080604_add_profile_photo_to_users.rb
+++ b/db/migrate/20200401080604_add_profile_photo_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfilePhotoToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :profile_photo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_01_062824) do
+ActiveRecord::Schema.define(version: 2020_04_01_080604) do
 
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "team"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_04_01_062824) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", default: "", null: false
+    t.string "profile_photo"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/favorites_controller_test.rb
+++ b/test/controllers/favorites_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FavoritesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- マイページの実装
    - ユーザーネームとメールアドレスを表示、編集ができる。
    - パスワードを入力しなくても編集できる。
    - 応援している選手などの表示、編集ができる